### PR TITLE
ENH : auto-rebuild

### DIFF
--- a/trackpy/linking.py
+++ b/trackpy/linking.py
@@ -39,6 +39,7 @@ class TreeFinder(object):
 
     def add_point(self, pt):
         self.points.append(pt)
+        self._clean = False
 
     def rebuild(self, coord_map=None):
         """Rebuilds tree from ``points`` attribute.
@@ -57,8 +58,15 @@ class TreeFinder(object):
         n = len(self.points)
         if n == 0:
             raise ValueError('Frame (aka level) contains zero points')
-        self.kdtree = cKDTree(coords, 15)
+        self._kdtree = cKDTree(coords, 15)
         # This could be tuned
+        self._clean = True
+
+    @property
+    def kdtree(self):
+        if not self._clean:
+            self.rebuild()
+        return self._kdtree
 
 
 class HashTable(object):
@@ -339,7 +347,7 @@ class PointND(Point):
     def __repr__(self):
         coords = '(' + (', '.join(["{:.3f}"]*len(self.pos))).format(*self.pos) + ')'
         track = " in Track %d" % self.track.indx if self.track else ""
-        return "<%s at %d, " % (self.__class__.__name__, self.t) + coords + track + ">" 
+        return "<%s at %d, " % (self.__class__.__name__, self.t) + coords + track + ">"
 
 class IndexedPointND(PointND):
 
@@ -372,7 +380,7 @@ def link(levels, search_range, hash_generator, memory=0, track_cls=None,
         algorithm used to resolve subnetworks of nearby particles
         'auto' uses numba if available
 
-    Returns  
+    Returns
     -------
     tracks : list of Track (or track_cls) objects
 
@@ -390,7 +398,7 @@ def link(levels, search_range, hash_generator, memory=0, track_cls=None,
     label_generator = link_iter(iter(levels), search_range, memory=memory,
                                 neighbor_strategy=neighbor_strategy,
                                 link_strategy=link_strategy,
-                                track_cls=track_cls, 
+                                track_cls=track_cls,
                                 hash_generator=hash_generator)
     labels = list(label_generator)
     points = sum(map(list, levels), [])  # flatten levels: a list of poits
@@ -430,7 +438,7 @@ def link_df(features, search_range, memory=0,
         Improve performance by guessing where a particle will be in the next frame.
         For examples of how this works, see the "predict" module.
 
-    Returns  
+    Returns
     -------
     trajectories : DataFrame
         This is the input features DataFrame, now with a new column labeling
@@ -446,7 +454,7 @@ def link_df(features, search_range, memory=0,
         For 'BTree' mode only. Define the shape of the search region.
         If None (default), infer shape from range of data.
     box_size : sequence
-        For 'BTree' mode only. Define the parition size to optimize 
+        For 'BTree' mode only. Define the parition size to optimize
         performance. If None (default), the search_range is used, which is
         a reasonable guess for best performance.
     verify_integrity : boolean
@@ -655,7 +663,7 @@ def link_iter(levels, search_range, memory=0,
         For 'BTree' mode only. Define the shape of the search region.
         (Higher-level wrappers of link infer this from the data.)
     box_size : sequence
-        For 'BTree' mode only. Define the parition size to optimize 
+        For 'BTree' mode only. Define the parition size to optimize
         performance. If None (default), the search_range is used, which is
         a reasonable guess for best performance.
     track_cls : class (optional)
@@ -707,7 +715,7 @@ def link_iter(levels, search_range, memory=0,
 
     try:
         # Start ID numbers from zero, incompatible with multithreading.
-        track_cls.reset_counter()  
+        track_cls.reset_counter()
     except AttributeError:
         # must be using a custom Track class without this method
         pass
@@ -761,7 +769,7 @@ def link_iter(levels, search_range, memory=0,
             p.forward_cands = []
 
         # Sort out what can go to what.
-        assign_candidates(cur_level, prev_hash, search_range, 
+        assign_candidates(cur_level, prev_hash, search_range,
                           neighbor_strategy)
 
         # sort the candidate lists by distance
@@ -823,7 +831,7 @@ def link_iter(levels, search_range, memory=0,
 
             spl, dpl = subnet_linker(s_sn, len(d_sn), search_range)
 
-            # Identify the particles in the destination set that 
+            # Identify the particles in the destination set that
             # were not linked to.
             d_remain = set(d for d in d_sn if d is not None)  # TODO DAN
             d_remain -= set(d for d in dpl if d is not None)
@@ -874,6 +882,7 @@ def link_iter(levels, search_range, memory=0,
                 prev_hash.add_point(m)
                 # re-create the forward_cands list
                 m.forward_cands = []
+
             # If the hash is a KDTree, it still needs to be rebuilt.
             # In the interests of efficiency, we do it at the top of the next
             # iteration, once we have dealt with prediction.
@@ -899,7 +908,7 @@ def assign_candidates(cur_level, prev_hash, search_range, neighbor_strategy):
         query = prev_hash.kdtree.query
         hashpts = prev_hash.points
         hashpts_len = len(hashpts)
-        # TODO: In scipy >= 0.12, 
+        # TODO: In scipy >= 0.12,
         # all neighbors for all particles can be found in one call!
         for p in cur_level:
             # get
@@ -909,7 +918,7 @@ def assign_candidates(cur_level, prev_hash, search_range, neighbor_strategy):
                     wp = hashpts[i]
                     if not np.isfinite(d):
                         i = None
-                        d = search_range   
+                        d = search_range
                     p.back_cands.append((wp, d))
                     wp.forward_cands.append((p, d))
                 else:


### PR DESCRIPTION
Don't need to call `rebuild` on TreeFinder, now does it automatically
when `kdtree` is accessed if needed.

If `rebuild` is called manually, this change has no effect. 

As you can't pass arguments to properties, not sure how to patch this up.  I suspect the coord_map can be cached, but I don't understand it will enough to be sure.
