### PR TITLE
REF: Use np.percentile in place of scoreatpercentile.

### DIFF
--- a/trackpy/feature.py
+++ b/trackpy/feature.py
@@ -6,7 +6,6 @@ import warnings
 import numpy as np
 import pandas as pd
 from scipy import ndimage
-from scipy import stats
 from scipy.spatial import cKDTree
 from pandas import DataFrame, Series
 
@@ -25,7 +24,7 @@ def percentile_threshold(image, percentile):
     not_black = image[np.nonzero(image)]
     if len(not_black) == 0:
         return np.nan
-    return stats.scoreatpercentile(not_black, percentile)
+    return np.percentile(not_black, percentile)
 
 
 def local_maxima(image, radius, separation=0, percentile=64):

--- a/trackpy/feature.py
+++ b/trackpy/feature.py
@@ -18,17 +18,25 @@ import trackpy  # to get trackpy.__version__
 
 from .try_numba import try_numba_autojit, NUMBA_AVAILABLE
 
+def percentile_threshold(image, percentile):
+    """Find grayscale threshold based on distribution in image."""
+
+    ndim = image.ndim
+    not_black = image[np.nonzero(image)]
+    if len(not_black) == 0:
+        return np.nan
+    return stats.scoreatpercentile(not_black, percentile)
+
 
 def local_maxima(image, radius, separation, percentile=64):
     """Find local maxima whose brightness is above a given percentile."""
 
     ndim = image.ndim
     # Compute a threshold based on percentile.
-    not_black = image[np.nonzero(image)]
-    if len(not_black) == 0:
+    threshold = percentile_threshold(image, percentile)
+    if np.isnan(threshold):
         warnings.warn("Image is completely black.", UserWarning)
         return np.empty((0, ndim))
-    threshold = stats.scoreatpercentile(not_black, percentile)
 
     # The intersection of the image with its dilation gives local maxima.
     if not np.issubdtype(image.dtype, np.integer):
@@ -50,8 +58,7 @@ def local_maxima(image, radius, separation, percentile=64):
         for pair in duplicates:
             # Take the average position.
             # This is just a starting point, so we won't go into subpx precision here.
-            merged = maxima[pair[0]]
-            merged = maxima[[pair[0], pair[1]]].mean(0).astype(int)
+            merged = maxima.take(pair, 0).mean(0).astype(int)
             maxima[pair[0]] = merged  # overwrite one
             to_drop.append(pair[1])  # queue other to be dropped
         maxima = np.delete(maxima, to_drop, 0)
@@ -138,7 +145,7 @@ def refine(raw_image, image, radius, coords, max_iterations=10, engine='auto',
                                       "images. You can extend it if you feel "
                                       "like a hero.")
         if walkthrough:
-            raise ValueError("walkthrough is not availabe in the nubma engine")
+            raise ValueError("walkthrough is not availabe in the numba engine")
         # Do some extra prep in pure Python that can't be done in numba.
         coords = np.array(coords, dtype=np.float_)
         shape = np.array(image.shape, dtype=np.int16)  # array, not tuple
@@ -417,7 +424,7 @@ def locate(raw_image, diameter, minmass=100., maxsize=None, separation=None,
     diameter : feature size in px
     minmass : minimum integrated brightness
         Default is 100, but a good value is often much higher. This is a
-        crucial parameter for elminating spurrious features.
+        crucial parameter for elminating spurious features.
     maxsize : maximum radius-of-gyration of brightness, default None
     separation : feature separation, in pixels
         Default is the feature diameter + 1.
@@ -430,7 +437,7 @@ def locate(raw_image, diameter, minmass=100., maxsize=None, separation=None,
     invert : Set to True if features are darker than background. False by
         default.
     percentile : Features must have a peak brighter than pixels in this
-        percentile. This helps eliminate spurrious peaks.
+        percentile. This helps eliminate spurious peaks.
     topn : Return only the N brightest features above minmass.
         If None (default), return all features above minmass.
 
@@ -447,11 +454,11 @@ def locate(raw_image, diameter, minmass=100., maxsize=None, separation=None,
     max_iterations : integer
         max number of loops to refine the center of mass, default 10
     filter_before : boolean
-        Use minmass (and maxsize, if set) to eliminate spurrious features
+        Use minmass (and maxsize, if set) to eliminate spurious features
         based on their estimated mass and size before refining position.
         True by default for performance.
     filter_after : boolean
-        Use final characterizations of mass and size to elminate spurrious
+        Use final characterizations of mass and size to eliminate spurious
         features. True by default.
     characterize : boolean
         Compute "extras": eccentricity, signal, ep. True by default.
@@ -617,7 +624,7 @@ def batch(frames, diameter, minmass=100, maxsize=None, separation=None,
     diameter : feature size in px
     minmass : minimum integrated brightness
         Default is 100, but a good value is often much higher. This is a
-        crucial parameter for elminating spurrious features.
+        crucial parameter for elminating spurious features.
     maxsize : maximum radius-of-gyration of brightness, default None
     separation : feature separation, in pixels
         Default is the feature diameter + 1.
@@ -630,7 +637,7 @@ def batch(frames, diameter, minmass=100, maxsize=None, separation=None,
     invert : Set to True if features are darker than background. False by
         default.
     percentile : Features must have a peak brighter than pixels in this
-        percentile. This helps eliminate spurrious peaks.
+        percentile. This helps eliminate spurious peaks.
     topn : Return only the N brightest features above minmass.
         If None (default), return all features above minmass.
 
@@ -647,11 +654,11 @@ def batch(frames, diameter, minmass=100, maxsize=None, separation=None,
     max_iterations : integer
         max number of loops to refine the center of mass, default 10
     filter_before : boolean
-        Use minmass (and maxsize, if set) to eliminate spurrious features
+        Use minmass (and maxsize, if set) to eliminate spurious features
         based on their estimated mass and size before refining position.
         True by default for performance.
     filter_after : boolean
-        Use final characterizations of mass and size to elminate spurrious
+        Use final characterizations of mass and size to elminate spurious
         features. True by default.
     characterize : boolean
         Compute "extras": eccentricity, signal, ep. True by default.

--- a/trackpy/feature.py
+++ b/trackpy/feature.py
@@ -66,8 +66,8 @@ def local_maxima(image, radius, separation=0, percentile=64):
 
     # Do not accept peaks near the edges.
     shape = np.array(image.shape)
-    margin = int(separation) // 2
-    near_edge = np.any((maxima < margin) | (maxima > (shape - margin)), 1)
+    margin = int(radius)
+    near_edge = np.any((maxima < margin) | (maxima > (shape - margin - 1)), 1)
     maxima = maxima[~near_edge]
     if not np.size(maxima) > 0:
         warnings.warn("All local maxima were in the margins.", UserWarning)

--- a/trackpy/masks.py
+++ b/trackpy/masks.py
@@ -7,7 +7,7 @@ import numpy as np
 from .utils import memo
 
 @memo
-def binary_mask(radius, ndim, separation=None):
+def binary_mask(radius, ndim):
     "circular mask in a square array"
     points = np.arange(-radius, radius + 1)
     if ndim > 1:

--- a/trackpy/tests/test_feature.py
+++ b/trackpy/tests/test_feature.py
@@ -196,6 +196,34 @@ class CommonFeatureIdentificationTests(object):
                            engine=self.engine)[cols]
         assert_allclose(actual, expected, atol=0.1)
 
+    def test_reject_peaks_near_edge(self):
+        """Check whether local maxima near the edge of the image
+        are properly rejected, so as not to cause crashes later."""
+        N = 30
+        diameter = 9
+        y = np.arange(20, 10*N + 1, 20)
+        x = np.linspace(diameter / 2. - 2, diameter * 1.5, len(y))
+        cols = ['x', 'y']
+        expected = DataFrame(np.vstack([x, y]).T, columns=cols)
+
+        dims = (y.max() - y.min() + 5*diameter, int(4 * diameter) - 2)
+        image = np.ones(dims, dtype='uint8')
+        for xpos, ypos in expected[['x', 'y']].values:
+            draw_gaussian_spot(image, [xpos, ypos], 4, max_value=100)
+        def locate(image, **kwargs):
+            return tp.locate(image, diameter, 1, preprocess=False,
+                             engine=self.engine, **kwargs)[cols]
+        # All we care about is that this doesn't crash
+        actual = locate(image)
+        assert len(actual)
+        # Check the other sides
+        actual = locate(np.fliplr(image))
+        assert len(actual)
+        actual = locate(image.transpose())
+        assert len(actual)
+        actual = locate(np.flipud(image.transpose()))
+        assert len(actual)
+
     def test_subpx_precision(self): 
         self.check_skip()
         L = 21


### PR DESCRIPTION
Code Review on a plane!

While we're revising the percentile code, let's follow [the recommendation in the scipy docs](http://docs.scipy.org/doc/scipy-0.14.0/reference/generated/scipy.stats.scoreatpercentile.html) (see the Note) and use `np.percentile` instead of `scipy.stats.scoreatpercentile`. The former is missing some features in numpy < 1.9 but none that we care about. Its basic functionality goes back before 1.6.

I can't measure any performance difference, in spite of what's promised by the Note. Perhaps the improvements do not apply to our use case. In any case, this removes an import and future-proofs.